### PR TITLE
Add support for MTM-CM5000MSP TelosB clone

### DIFF
--- a/core/src/main/resources/devicelist-linux
+++ b/core/src/main/resources/devicelist-linux
@@ -240,6 +240,11 @@ EOF
       $dev->{InfoManufacturer} = "";
     }
 
+    if ($dev->{InfoProduct} eq "MTM-CM5000MSP") {
+      $dev->{InfoProduct} = "telosb";
+      $dev->{InfoManufacturer} = "";
+    }
+
     if ($dev->{InfoProduct} eq "USB <-> Serial"){
       $dev->{InfoProduct} = "isense";
       $dev->{InfoManufacturer} = "";

--- a/core/src/main/resources/devicelist-macosx
+++ b/core/src/main/resources/devicelist-macosx
@@ -79,6 +79,8 @@ EOF
       $desc = "pacemate";
     } elsif ($firstLetterSerial eq "A") {
       $desc = "xbee";
+    } elsif (substr($dev->{"InfoSerial"}, 0, 4) eq "MFUD") {
+      $desc = "telosb";
     } elsif ($firstLetterSerial eq "X") {
       $desc = "telosb";
     } else {

--- a/core/src/main/resources/devicelist-windowsxp.cpp
+++ b/core/src/main/resources/devicelist-windowsxp.cpp
@@ -382,7 +382,8 @@ ListDevice getDevices()
         d.info = usb6001[d.id]("LocationInformation").data; 
         
 	is_isense = strcmp(d.info.c_str(), "USB <-> Serial") == 0;
-        is_telosb = strcmp(d.info.c_str(), "Crossbow Telos Rev.B") == 0;
+        is_telosb = (strcmp(d.info.c_str(), "Crossbow Telos Rev.B") == 0) ||
+		(strcmp(d.info.c_str(), "MTM-CM5000MSP") == 0);
         is_xbee = strcmp(d.info.c_str(), "FT232R USB UART") == 0;
 
         if (is_isense)


### PR DESCRIPTION
Added USB product/serial detection strings for MTM-CM5000MSP TelosB clone (untested on OSX, Windows)
