### PR TITLE
removed redundant newlines in StringWriter

### DIFF
--- a/core/src/main/java/de/uniluebeck/itm/wsn/deviceutils/listener/StringWriter.java
+++ b/core/src/main/java/de/uniluebeck/itm/wsn/deviceutils/listener/StringWriter.java
@@ -45,7 +45,6 @@ public class StringWriter extends WriterHandler {
 		super.messageReceived(ctx, e);
 
 		output.write(((ChannelBuffer) e.getMessage()).toString(charset));
-		output.newLine();
 		output.flush();
 	}
 }


### PR DESCRIPTION
Hi,

I just removed the redundant new lines in the StringWriter. This makes the output much more readable and now the StringWriter output is the same as the original output.
In addition I did not find a case where it is necessary to add these new lines.

Regards 

Georg von Zengen
